### PR TITLE
✨ Add match data fetching functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "eslint.useFlatConfig": true
+  "eslint.useFlatConfig": true,
+  "cSpell.words": ["puuid", "PUUID"]
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
+    "@next/eslint-plugin-next": "^15.5.6",
     "@tailwindcss/postcss": "^4.1.12",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.19.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3.3.1
         version: 3.3.1
+      '@next/eslint-plugin-next':
+        specifier: ^15.5.6
+        version: 15.5.6
       '@tailwindcss/postcss':
         specifier: ^4.1.12
         version: 4.1.12
@@ -595,6 +598,9 @@ packages:
 
   '@next/eslint-plugin-next@15.5.2':
     resolution: {integrity: sha512-lkLrRVxcftuOsJNhWatf1P2hNVfh98k/omQHrCEPPriUypR6RcS13IvLdIrEvkm9AH2Nu2YpR5vLqBuy6twH3Q==}
+
+  '@next/eslint-plugin-next@15.5.6':
+    resolution: {integrity: sha512-YxDvsT2fwy1j5gMqk3ppXlsgDopHnkM4BoxSVASbvvgh5zgsK8lvWerDzPip8k3WVzsTZ1O7A7si1KNfN4OZfQ==}
 
   '@next/swc-darwin-arm64@15.5.2':
     resolution: {integrity: sha512-8bGt577BXGSd4iqFygmzIfTYizHb0LGWqH+qgIF/2EDxS5JsSdERJKA8WgwDyNBZgTIIA4D8qUtoQHmxIIquoQ==}
@@ -2792,6 +2798,10 @@ snapshots:
   '@next/env@15.5.2': {}
 
   '@next/eslint-plugin-next@15.5.2':
+    dependencies:
+      fast-glob: 3.3.1
+
+  '@next/eslint-plugin-next@15.5.6':
     dependencies:
       fast-glob: 3.3.1
 

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,5 +1,6 @@
+import { ReactNode } from 'react';
 import './style.css';
 
-export default async function AppLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+export default async function AppLayout({ children }: Readonly<{ children: ReactNode }>) {
   return children;
 }

--- a/src/app/api/match/current/route.ts
+++ b/src/app/api/match/current/route.ts
@@ -1,0 +1,23 @@
+import { getCurrentMatchByGameNameAndTagLine } from '@/lib/matchApi';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const gameName = searchParams.get('gameName');
+  const tagLine = searchParams.get('tagLine');
+
+  if (!gameName || !tagLine) {
+    return NextResponse.json(
+      { error: 'Missing required parameters: gameName and tagLine' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const participants = await getCurrentMatchByGameNameAndTagLine(gameName, tagLine);
+    return NextResponse.json({ participants });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to fetch match data';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/match/current/route.ts
+++ b/src/app/api/match/current/route.ts
@@ -27,12 +27,15 @@ export async function GET(request: NextRequest) {
   } catch (error: unknown) {
     // Handle custom MatchApiError with proper status codes
     if (error instanceof MatchApiError) {
-      log.error(`Unexpected error fetching match data: ${error.statusCode} ${error.message}`);
+      log.error(
+        `MatchApiError while fetching match data: ${error.statusCode} ${error.message}`,
+        error,
+      );
       return NextResponse.json({ error: error.message }, { status: error.statusCode });
     }
 
     // Fallback for unexpected errors
-    log.error(`Unexpected error fetching match data: ${error}`);
+    log.error('Unexpected error fetching match data', error);
     return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
   }
 }

--- a/src/app/api/match/current/route.ts
+++ b/src/app/api/match/current/route.ts
@@ -1,4 +1,5 @@
-import { getCurrentMatchByGameNameAndTagLine, MatchApiError } from '@/lib/matchApi';
+import { getCurrentMatchByGameNameAndTagLine } from '@/lib/matchApi';
+import { MatchApiError } from '@/types/MatchApiError';
 import { logger } from '@/utils/logger';
 import { NextRequest, NextResponse } from 'next/server';
 

--- a/src/app/api/match/current/route.ts
+++ b/src/app/api/match/current/route.ts
@@ -1,7 +1,10 @@
-import { getCurrentMatchByGameNameAndTagLine } from '@/lib/matchApi';
+import { getCurrentMatchByGameNameAndTagLine, MatchApiError } from '@/lib/matchApi';
+import { logger } from '@/utils/logger';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest) {
+  const log = logger.child('api:match:current');
+
   const searchParams = request.nextUrl.searchParams;
   const gameName = searchParams.get('gameName')?.trim();
   const tagLine = searchParams.get('tagLine')?.trim();
@@ -12,12 +15,23 @@ export async function GET(request: NextRequest) {
       { status: 400 },
     );
   }
+  // tagLine is typically 3-5 alphanumeric
+  if (!/^[a-zA-Z0-9]{3,5}$/.test(tagLine)) {
+    return NextResponse.json({ error: 'Invalid tagLine format' }, { status: 400 });
+  }
 
   try {
     const participants = await getCurrentMatchByGameNameAndTagLine(gameName, tagLine);
     return NextResponse.json({ participants });
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : 'Failed to fetch match data';
-    return NextResponse.json({ error: message }, { status: 500 });
+    // Handle custom MatchApiError with proper status codes
+    if (error instanceof MatchApiError) {
+      log.error(`Unexpected error fetching match data: ${error.statusCode} ${error.message}`);
+      return NextResponse.json({ error: error.message }, { status: error.statusCode });
+    }
+
+    // Fallback for unexpected errors
+    log.error(`Unexpected error fetching match data: ${error}`);
+    return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
   }
 }

--- a/src/app/api/match/current/route.ts
+++ b/src/app/api/match/current/route.ts
@@ -3,8 +3,8 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
-  const gameName = searchParams.get('gameName');
-  const tagLine = searchParams.get('tagLine');
+  const gameName = searchParams.get('gameName')?.trim();
+  const tagLine = searchParams.get('tagLine')?.trim();
 
   if (!gameName || !tagLine) {
     return NextResponse.json(

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { ReactNode } from 'react';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -9,7 +10,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <html lang="en">

--- a/src/app/overlay/layout.tsx
+++ b/src/app/overlay/layout.tsx
@@ -1,5 +1,6 @@
+import { ReactNode } from 'react';
 import './style.css';
 
-export default async function OverlayLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+export default async function OverlayLayout({ children }: Readonly<{ children: ReactNode }>) {
   return children;
 }

--- a/src/components/OverlayForm/OverlayForm.tsx
+++ b/src/components/OverlayForm/OverlayForm.tsx
@@ -24,7 +24,7 @@ export function OverlayForm({
     setError,
   } = useForm<{ matchOf: string }>();
 
-  const { register, handleSubmit, setValue } = useForm<TOverlay>({
+  const { register, handleSubmit, setValue, getValues } = useForm<TOverlay>({
     defaultValues: {
       ...(defaultValues || {
         blueTeam: Array.from({ length: 5 }, () => ({
@@ -42,7 +42,7 @@ export function OverlayForm({
   });
 
   const handleSearchMatchOf = async (data: { matchOf: string }) => {
-    const { matchOf } = data;
+    const matchOf = data.matchOf.trim();
 
     if (Strings.isBlank(matchOf)) {
       return;
@@ -54,23 +54,23 @@ export function OverlayForm({
       const blueTeam = participants
         .filter((p) => p.teamId === 100)
         .map((p) => ({
-          playerName: p.riotId.replace(/#[^#]*$/, '') || '',
+          playerName: (String(p.riotId) || '').replace(/#[^#]*$/, '') || '',
           championName: p.championName || '',
           teamName: '',
         }));
       const redTeam = participants
         .filter((p) => p.teamId === 200)
         .map((p) => ({
-          playerName: p.riotId.replace(/#[^#]*$/, '') || '',
+          playerName: (String(p.riotId) || '').replace(/#[^#]*$/, '') || '',
           championName: p.championName || '',
           teamName: '',
         }));
       setValue('blueTeam', blueTeam);
       setValue('redTeam', redTeam);
-    } catch (error: any) {
+    } catch (error: unknown) {
       setError('matchOf', {
         type: 'manual',
-        message: error.message,
+        message: (error as Error)?.message ?? 'Failed to load match data',
       });
     }
   };
@@ -114,13 +114,23 @@ export function OverlayForm({
             className={`flex grow basis-xl flex-col gap-2 rounded-2xl border border-blue-600 bg-blue-50 px-5 py-3`}
           >
             <h2 className={`text-blue-600`}>Blue team</h2>
-            <PlayersForm register={register} setValue={setValue} teamName="blueTeam" />
+            <PlayersForm
+              register={register}
+              setValue={setValue}
+              getValues={getValues}
+              teamName="blueTeam"
+            />
           </div>
           <div
             className={`flex grow basis-xl flex-col gap-2 rounded-2xl border border-red-600 bg-red-50 px-5 py-3`}
           >
             <h2 className={`text-red-600`}>Red team</h2>
-            <PlayersForm register={register} setValue={setValue} teamName="redTeam" />
+            <PlayersForm
+              register={register}
+              setValue={setValue}
+              getValues={getValues}
+              teamName="redTeam"
+            />
           </div>
         </div>
         <button

--- a/src/components/OverlayForm/OverlayForm.tsx
+++ b/src/components/OverlayForm/OverlayForm.tsx
@@ -50,6 +50,14 @@ export function OverlayForm({
     }
 
     const [gameName, tagLine] = matchOf.split('#');
+    if (Strings.isBlank(gameName) || Strings.isBlank(tagLine)) {
+      setError('matchOf', {
+        type: 'manual',
+        message: 'Format must be gameName#tagLine',
+      });
+      return;
+    }
+
     try {
       setLoading(true);
       const response = await fetch(

--- a/src/components/OverlayForm/OverlayForm.tsx
+++ b/src/components/OverlayForm/OverlayForm.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { getCurrentMatchByGameNameAndTagLine } from '@/lib/matchApi';
 import { TOverlay } from '@/types/OverlayType';
 import { Strings } from '@/utils/stringUtils';
 import { useState } from 'react';
@@ -53,17 +52,26 @@ export function OverlayForm({
     const [gameName, tagLine] = matchOf.split('#');
     try {
       setLoading(true);
-      const participants = await getCurrentMatchByGameNameAndTagLine(gameName, tagLine);
+      const response = await fetch(
+        `/api/match/current?gameName=${encodeURIComponent(gameName)}&tagLine=${encodeURIComponent(tagLine)}`,
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Failed to load match data');
+      }
+
+      const { participants } = await response.json();
       const blueTeam = participants
-        .filter((p) => p.teamId === 100)
-        .map((p) => ({
+        .filter((p: { teamId: number }) => p.teamId === 100)
+        .map((p: { riotId?: string; championName?: string }) => ({
           playerName: p.riotId?.replace(/#[^#]*$/, '') || '',
           championName: p.championName || '',
           teamName: '',
         }));
       const redTeam = participants
-        .filter((p) => p.teamId === 200)
-        .map((p) => ({
+        .filter((p: { teamId: number }) => p.teamId === 200)
+        .map((p: { riotId?: string; championName?: string }) => ({
           playerName: p.riotId?.replace(/#[^#]*$/, '') || '',
           championName: p.championName || '',
           teamName: '',

--- a/src/components/OverlayForm/OverlayForm.tsx
+++ b/src/components/OverlayForm/OverlayForm.tsx
@@ -54,14 +54,14 @@ export function OverlayForm({
       const blueTeam = participants
         .filter((p) => p.teamId === 100)
         .map((p) => ({
-          playerName: (String(p.riotId) || '').replace(/#[^#]*$/, '') || '',
+          playerName: p.riotId?.replace(/#[^#]*$/, '') || '',
           championName: p.championName || '',
           teamName: '',
         }));
       const redTeam = participants
         .filter((p) => p.teamId === 200)
         .map((p) => ({
-          playerName: (String(p.riotId) || '').replace(/#[^#]*$/, '') || '',
+          playerName: p.riotId?.replace(/#[^#]*$/, '') || '',
           championName: p.championName || '',
           teamName: '',
         }));

--- a/src/components/OverlayForm/OverlayForm.tsx
+++ b/src/components/OverlayForm/OverlayForm.tsx
@@ -70,13 +70,13 @@ export function OverlayForm({
   };
 
   return (
-    <>
+    <div className="flex flex-col gap-6">
       <form
         className="flex w-full flex-row items-center gap-4"
         onSubmit={handleMatchOfSubmit(handleSearchMatchOf)}
       >
         <div className="flex w-100 flex-col">
-          <label htmlFor="matchOf" className="pb-1 pl-0.5 text-xs text-gray-500">
+          <label htmlFor="matchOf" className="pb-1 pl-0.5 text-gray-500">
             Load data from match of :
           </label>
           <input
@@ -124,6 +124,6 @@ export function OverlayForm({
           {submitLabel}
         </button>
       </form>
-    </>
+    </div>
   );
 }

--- a/src/components/OverlayForm/OverlayForm.tsx
+++ b/src/components/OverlayForm/OverlayForm.tsx
@@ -48,14 +48,14 @@ export function OverlayForm({
       const blueTeam = participants
         .filter((p) => p.teamId === 100)
         .map((p) => ({
-          playerName: p.riotId.replace(/#.*$/, '') || '',
+          playerName: p.riotId.replace(/#[^#]*$/, '') || '',
           championName: p.championName || '',
           teamName: '',
         }));
       const redTeam = participants
         .filter((p) => p.teamId === 200)
         .map((p) => ({
-          playerName: p.riotId.replace(/#.*$/, '') || '',
+          playerName: p.riotId.replace(/#[^#]*$/, '') || '',
           championName: p.championName || '',
           teamName: '',
         }));
@@ -86,7 +86,7 @@ export function OverlayForm({
             placeholder="gameName#tagLine"
             {...registerMatchOf('matchOf', {
               pattern: {
-                value: /.+#.+/,
+                value: /^[^#]+#[^#]+$/,
                 message: 'Format must be gameName#tagLine',
               },
             })}

--- a/src/components/OverlayForm/OverlayForm.tsx
+++ b/src/components/OverlayForm/OverlayForm.tsx
@@ -3,6 +3,7 @@
 import { getCurrentMatchByGameNameAndTagLine } from '@/lib/matchApi';
 import { TOverlay } from '@/types/OverlayType';
 import { Strings } from '@/utils/stringUtils';
+import { useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { PlayersForm } from './PlayersForm/PlayersForm';
 
@@ -23,6 +24,7 @@ export function OverlayForm({
     formState: { errors: matchOfErrors },
     setError,
   } = useForm<{ matchOf: string }>();
+  const [loading, setLoading] = useState(false);
 
   const { register, handleSubmit, setValue, getValues } = useForm<TOverlay>({
     defaultValues: {
@@ -50,6 +52,7 @@ export function OverlayForm({
 
     const [gameName, tagLine] = matchOf.split('#');
     try {
+      setLoading(true);
       const participants = await getCurrentMatchByGameNameAndTagLine(gameName, tagLine);
       const blueTeam = participants
         .filter((p) => p.teamId === 100)
@@ -72,6 +75,8 @@ export function OverlayForm({
         type: 'manual',
         message: (error as Error)?.message ?? 'Failed to load match data',
       });
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -105,7 +110,7 @@ export function OverlayForm({
           className="self-center rounded-2xl bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
           type="submit"
         >
-          Load data
+          {loading ? 'Loading...' : 'Load data'}
         </button>
       </form>
       <form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmit)}>

--- a/src/components/OverlayForm/OverlayForm.tsx
+++ b/src/components/OverlayForm/OverlayForm.tsx
@@ -73,7 +73,7 @@ export function OverlayForm({
     } catch (error: unknown) {
       setError('matchOf', {
         type: 'manual',
-        message: (error as Error)?.message ?? 'Failed to load match data',
+        message: error instanceof Error ? error.message : 'Failed to load match data',
       });
     } finally {
       setLoading(false);
@@ -107,8 +107,9 @@ export function OverlayForm({
           )}
         </div>
         <button
-          className="self-center rounded-2xl bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+          className="self-center rounded-2xl bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
           type="submit"
+          disabled={loading}
         >
           {loading ? 'Loading...' : 'Load data'}
         </button>

--- a/src/components/OverlayForm/OverlayForm.tsx
+++ b/src/components/OverlayForm/OverlayForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { getCurrentMatchByGameNameAndTagLine } from '@/lib/matchApi';
 import { TOverlay } from '@/types/OverlayType';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { PlayersForm } from './PlayersForm/PlayersForm';
@@ -15,6 +16,13 @@ export function OverlayForm({
   submitLabel = 'Generate Overlay',
   defaultValues,
 }: Readonly<OverlayFormProps>) {
+  const {
+    register: registerMatchOf,
+    handleSubmit: handleMatchOfSubmit,
+    formState: { errors: matchOfErrors },
+    setError,
+  } = useForm<{ matchOf: string }>();
+
   const { register, handleSubmit, setValue } = useForm<TOverlay>({
     defaultValues: {
       ...(defaultValues || {
@@ -32,28 +40,90 @@ export function OverlayForm({
     },
   });
 
+  const handleSearchMatchOf = async (data: { matchOf: string }) => {
+    const { matchOf } = data;
+    const [gameName, tagLine] = matchOf.split('#');
+    try {
+      const participants = await getCurrentMatchByGameNameAndTagLine(gameName, tagLine);
+      const blueTeam = participants
+        .filter((p) => p.teamId === 100)
+        .map((p) => ({
+          playerName: p.riotId.replace(/#.*$/, '') || '',
+          championName: p.championName || '',
+          teamName: '',
+        }));
+      const redTeam = participants
+        .filter((p) => p.teamId === 200)
+        .map((p) => ({
+          playerName: p.riotId.replace(/#.*$/, '') || '',
+          championName: p.championName || '',
+          teamName: '',
+        }));
+      setValue('blueTeam', blueTeam);
+      setValue('redTeam', redTeam);
+    } catch (error: any) {
+      setError('matchOf', {
+        type: 'manual',
+        message: error.message,
+      });
+    }
+  };
+
   return (
-    <form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmit)}>
-      <div className="flex flex-row flex-wrap gap-4">
-        <div
-          className={`flex grow basis-xl flex-col gap-2 rounded-2xl border border-blue-600 bg-blue-50 px-5 py-3`}
-        >
-          <h2 className={`text-blue-600`}>Blue team</h2>
-          <PlayersForm register={register} setValue={setValue} teamName="blueTeam" />
-        </div>
-        <div
-          className={`flex grow basis-xl flex-col gap-2 rounded-2xl border border-red-600 bg-red-50 px-5 py-3`}
-        >
-          <h2 className={`text-red-600`}>Red team</h2>
-          <PlayersForm register={register} setValue={setValue} teamName="redTeam" />
-        </div>
-      </div>
-      <button
-        type="submit"
-        className="self-center rounded-2xl bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+    <>
+      <form
+        className="flex w-full flex-row items-center gap-4"
+        onSubmit={handleMatchOfSubmit(handleSearchMatchOf)}
       >
-        {submitLabel}
-      </button>
-    </form>
+        <div className="flex w-100 flex-col">
+          <label htmlFor="matchOf" className="pb-1 pl-0.5 text-xs text-gray-500">
+            Load data from match of :
+          </label>
+          <input
+            id="matchOf"
+            type="text"
+            className="rounded-lg border border-gray-300 bg-white px-2 py-1 shadow-sm transition-all outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+            placeholder="gameName#tagLine"
+            {...registerMatchOf('matchOf', {
+              pattern: {
+                value: /.+#.+/,
+                message: 'Format must be gameName#tagLine',
+              },
+            })}
+          />
+          {matchOfErrors.matchOf && (
+            <p className="text-xs text-red-500">{matchOfErrors.matchOf.message}</p>
+          )}
+        </div>
+        <button
+          className="self-center rounded-2xl bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+          type="submit"
+        >
+          Load data
+        </button>
+      </form>
+      <form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmit)}>
+        <div className="flex flex-row flex-wrap gap-4">
+          <div
+            className={`flex grow basis-xl flex-col gap-2 rounded-2xl border border-blue-600 bg-blue-50 px-5 py-3`}
+          >
+            <h2 className={`text-blue-600`}>Blue team</h2>
+            <PlayersForm register={register} setValue={setValue} teamName="blueTeam" />
+          </div>
+          <div
+            className={`flex grow basis-xl flex-col gap-2 rounded-2xl border border-red-600 bg-red-50 px-5 py-3`}
+          >
+            <h2 className={`text-red-600`}>Red team</h2>
+            <PlayersForm register={register} setValue={setValue} teamName="redTeam" />
+          </div>
+        </div>
+        <button
+          type="submit"
+          className="self-center rounded-2xl bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+        >
+          {submitLabel}
+        </button>
+      </form>
+    </>
   );
 }

--- a/src/components/OverlayForm/OverlayForm.tsx
+++ b/src/components/OverlayForm/OverlayForm.tsx
@@ -2,6 +2,7 @@
 
 import { getCurrentMatchByGameNameAndTagLine } from '@/lib/matchApi';
 import { TOverlay } from '@/types/OverlayType';
+import { Strings } from '@/utils/stringUtils';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { PlayersForm } from './PlayersForm/PlayersForm';
 
@@ -42,6 +43,11 @@ export function OverlayForm({
 
   const handleSearchMatchOf = async (data: { matchOf: string }) => {
     const { matchOf } = data;
+
+    if (Strings.isBlank(matchOf)) {
+      return;
+    }
+
     const [gameName, tagLine] = matchOf.split('#');
     try {
       const participants = await getCurrentMatchByGameNameAndTagLine(gameName, tagLine);

--- a/src/components/OverlayForm/PlayersForm/PlayerForm.tsx
+++ b/src/components/OverlayForm/PlayersForm/PlayerForm.tsx
@@ -7,9 +7,29 @@ type PlayerFormProps = {
   register: UseFormRegister<TOverlay>;
   setValue: UseFormSetValue<TOverlay>;
   fieldPrefix: `${TeamEnum}.${number}`;
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
+  onDragOver?: (e: React.DragEvent) => void;
+  onDragLeave?: () => void;
+  onDrop?: (e: React.DragEvent) => void;
+  isDragging?: boolean;
+  isDragOver?: boolean;
+  showIndicatorAbove?: boolean;
 };
 
-export function PlayerForm({ register, setValue, fieldPrefix }: Readonly<PlayerFormProps>) {
+export function PlayerForm({
+  register,
+  setValue,
+  fieldPrefix,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  isDragging = false,
+  isDragOver = false,
+  showIndicatorAbove = false,
+}: Readonly<PlayerFormProps>) {
   const clearPlayer = () => {
     setValue(`${fieldPrefix}.championName`, '');
     setValue(`${fieldPrefix}.playerName`, '');
@@ -17,41 +37,63 @@ export function PlayerForm({ register, setValue, fieldPrefix }: Readonly<PlayerF
   };
 
   return (
-    <div className="flex flex-row gap-2">
-      <div className="flex w-20 flex-col">
-        <label htmlFor={`team-${fieldPrefix}`} className="pb-1 pl-0.5 text-xs text-gray-500">
-          Équipe
-        </label>
-        <input
-          id={`team-${fieldPrefix}`}
-          type="text"
-          className="rounded-lg border border-gray-300 bg-white px-2 py-1 shadow-sm transition-all outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
-          {...register(`${fieldPrefix}.teamName`)}
-        />
-      </div>
-      <div className="flex grow flex-col">
-        <label htmlFor={`player-${fieldPrefix}`} className="pb-1 pl-0.5 text-xs text-gray-500">
-          Joueur
-        </label>
-        <input
-          id={`player-${fieldPrefix}`}
-          type="text"
-          className="grow rounded-lg border border-gray-300 bg-white px-2 py-1 shadow-sm transition-all outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
-          {...register(`${fieldPrefix}.playerName`)}
-        />
-      </div>
-      <div className="flex grow flex-col">
-        <ChampionField register={register} fieldPrefix={fieldPrefix} />
-      </div>
-      <div className="flex flex-col justify-end">
-        <button
-          type="button"
-          onClick={clearPlayer}
-          className="rounded-lg border border-red-300 bg-red-50 px-3 py-1 text-red-600 transition-all hover:border-red-400 hover:bg-red-100"
-          title="Clear player"
-        >
-          ✕
-        </button>
+    <div className="relative">
+      {isDragOver && (
+        <div
+          className={`absolute right-0 left-0 z-10 h-1 rounded-full bg-blue-500 shadow-lg ${
+            showIndicatorAbove ? '-top-1' : '-bottom-1'
+          }`}
+        ></div>
+      )}
+      <div
+        className={`flex flex-row gap-2 rounded-lg transition-all ${isDragging ? 'opacity-50' : ''}`}
+        draggable
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+      >
+        <div className="flex cursor-move flex-col justify-center rounded bg-gray-200 px-1.5 text-gray-600 transition-colors hover:bg-gray-300 hover:text-gray-800">
+          <span className="font-bold" title="Drag to reorder">
+            ⋮⋮
+          </span>
+        </div>
+        <div className="flex w-20 flex-col">
+          <label htmlFor={`team-${fieldPrefix}`} className="pb-1 pl-0.5 text-xs text-gray-500">
+            Équipe
+          </label>
+          <input
+            id={`team-${fieldPrefix}`}
+            type="text"
+            className="rounded-lg border border-gray-300 bg-white px-2 py-1 shadow-sm transition-all outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+            {...register(`${fieldPrefix}.teamName`)}
+          />
+        </div>
+        <div className="flex grow flex-col">
+          <label htmlFor={`player-${fieldPrefix}`} className="pb-1 pl-0.5 text-xs text-gray-500">
+            Joueur
+          </label>
+          <input
+            id={`player-${fieldPrefix}`}
+            type="text"
+            className="grow rounded-lg border border-gray-300 bg-white px-2 py-1 shadow-sm transition-all outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+            {...register(`${fieldPrefix}.playerName`)}
+          />
+        </div>
+        <div className="flex grow flex-col">
+          <ChampionField register={register} fieldPrefix={fieldPrefix} />
+        </div>
+        <div className="flex flex-col justify-end">
+          <button
+            type="button"
+            onClick={clearPlayer}
+            className="rounded-lg border border-red-300 bg-red-50 px-3 py-1 text-red-600 transition-all hover:border-red-400 hover:bg-red-100"
+            title="Clear player"
+          >
+            ✕
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/OverlayForm/PlayersForm/PlayerForm.tsx
+++ b/src/components/OverlayForm/PlayersForm/PlayerForm.tsx
@@ -1,5 +1,6 @@
 import { TOverlay } from '@/types/OverlayType';
 import { TeamEnum } from '@/types/TeamEnum';
+import { DragEvent } from 'react';
 import { UseFormRegister, UseFormSetValue } from 'react-hook-form';
 import { ChampionField } from './ChampionField/ChampionField';
 
@@ -9,9 +10,9 @@ type PlayerFormProps = {
   fieldPrefix: `${TeamEnum}.${number}`;
   onDragStart?: () => void;
   onDragEnd?: () => void;
-  onDragOver?: (e: React.DragEvent) => void;
+  onDragOver?: (e: DragEvent) => void;
   onDragLeave?: () => void;
-  onDrop?: (e: React.DragEvent) => void;
+  onDrop?: (e: DragEvent) => void;
   isDragging?: boolean;
   isDragOver?: boolean;
   showIndicatorAbove?: boolean;

--- a/src/components/OverlayForm/PlayersForm/PlayersForm.tsx
+++ b/src/components/OverlayForm/PlayersForm/PlayersForm.tsx
@@ -1,5 +1,6 @@
 import { TOverlay } from '@/types/OverlayType';
 import { TeamEnum } from '@/types/TeamEnum';
+import { useState } from 'react';
 import { UseFormRegister, UseFormSetValue } from 'react-hook-form';
 import { PlayerForm } from './PlayerForm';
 
@@ -10,6 +11,74 @@ type PlayersFormProps = {
 };
 
 export function PlayersForm({ register, setValue, teamName }: Readonly<PlayersFormProps>) {
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const [showIndicatorAbove, setShowIndicatorAbove] = useState<boolean>(false);
+
+  const handleDragStart = (index: number) => {
+    setDraggedIndex(index);
+  };
+
+  const handleDragEnd = () => {
+    setDraggedIndex(null);
+    setDragOverIndex(null);
+    setShowIndicatorAbove(false);
+  };
+
+  const handleDragOver = (e: React.DragEvent, index: number) => {
+    e.preventDefault();
+    if (draggedIndex !== null && draggedIndex !== index) {
+      setDragOverIndex(index);
+      // Show indicator above if dragging from below to above
+      setShowIndicatorAbove(draggedIndex > index);
+    }
+  };
+
+  const handleDragLeave = () => {
+    setDragOverIndex(null);
+    setShowIndicatorAbove(false);
+  };
+
+  const handleDrop = (e: React.DragEvent, dropIndex: number) => {
+    e.preventDefault();
+
+    if (draggedIndex === null || draggedIndex === dropIndex) {
+      setDragOverIndex(null);
+      return;
+    }
+
+    // Get current values from the form
+    const players = [0, 1, 2, 3, 4].map((i) => ({
+      playerName:
+        (document.getElementById(`player-${teamName}.${i}`) as HTMLInputElement)?.value || '',
+      championName:
+        (document.getElementById(`champion-${teamName}.${i}`) as HTMLInputElement)?.value || '',
+      teamName: (document.getElementById(`team-${teamName}.${i}`) as HTMLInputElement)?.value || '',
+    }));
+
+    // Insert the dragged player at the drop position
+    // Remove the dragged player from its original position
+    const [draggedPlayer] = players.splice(draggedIndex, 1);
+
+    // Calculate the correct insertion index
+    // If dragging down, the index doesn't need adjustment
+    // If dragging up, insert at the exact dropIndex
+    const insertIndex = draggedIndex < dropIndex ? dropIndex : dropIndex;
+
+    // Insert at the target position
+    players.splice(insertIndex, 0, draggedPlayer);
+
+    // Update all players in the form
+    players.forEach((player, index) => {
+      setValue(`${teamName}.${index}.playerName`, player.playerName);
+      setValue(`${teamName}.${index}.championName`, player.championName);
+      setValue(`${teamName}.${index}.teamName`, player.teamName);
+    });
+
+    setDraggedIndex(null);
+    setDragOverIndex(null);
+  };
+
   return (
     <div className="flex flex-col gap-2">
       {[0, 1, 2, 3, 4].map((i) => (
@@ -18,6 +87,14 @@ export function PlayersForm({ register, setValue, teamName }: Readonly<PlayersFo
           register={register}
           setValue={setValue}
           fieldPrefix={`${teamName}.${i}`}
+          onDragStart={() => handleDragStart(i)}
+          onDragEnd={handleDragEnd}
+          onDragOver={(e) => handleDragOver(e, i)}
+          onDragLeave={handleDragLeave}
+          onDrop={(e) => handleDrop(e, i)}
+          isDragging={draggedIndex === i}
+          isDragOver={dragOverIndex === i}
+          showIndicatorAbove={showIndicatorAbove && dragOverIndex === i}
         />
       ))}
     </div>

--- a/src/components/OverlayForm/PlayersForm/PlayersForm.tsx
+++ b/src/components/OverlayForm/PlayersForm/PlayersForm.tsx
@@ -1,6 +1,6 @@
 import { TOverlay } from '@/types/OverlayType';
 import { TeamEnum } from '@/types/TeamEnum';
-import { useState } from 'react';
+import { DragEvent, useState } from 'react';
 import { UseFormRegister, UseFormSetValue } from 'react-hook-form';
 import { PlayerForm } from './PlayerForm';
 
@@ -25,7 +25,7 @@ export function PlayersForm({ register, setValue, teamName }: Readonly<PlayersFo
     setShowIndicatorAbove(false);
   };
 
-  const handleDragOver = (e: React.DragEvent, index: number) => {
+  const handleDragOver = (e: DragEvent, index: number) => {
     e.preventDefault();
     if (draggedIndex !== null && draggedIndex !== index) {
       setDragOverIndex(index);
@@ -39,7 +39,7 @@ export function PlayersForm({ register, setValue, teamName }: Readonly<PlayersFo
     setShowIndicatorAbove(false);
   };
 
-  const handleDrop = (e: React.DragEvent, dropIndex: number) => {
+  const handleDrop = (e: DragEvent, dropIndex: number) => {
     e.preventDefault();
 
     if (draggedIndex === null || draggedIndex === dropIndex) {

--- a/src/context/ChampionsContext.tsx
+++ b/src/context/ChampionsContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { TChampion } from '@/types/ChampionType';
-import { createContext, useContext, useMemo } from 'react';
+import { createContext, ReactNode, useContext, useMemo } from 'react';
 
 type ChampionsContextValue = {
   champions: TChampion[];
@@ -12,7 +12,7 @@ const ChampionsContext = createContext<ChampionsContextValue | undefined>(undefi
 export function ChampionsProvider({
   champions,
   children,
-}: Readonly<{ champions: TChampion[]; children: React.ReactNode }>) {
+}: Readonly<{ champions: TChampion[]; children: ReactNode }>) {
   const value = useMemo<ChampionsContextValue>(() => ({ champions }), [champions]);
   return <ChampionsContext.Provider value={value}>{children}</ChampionsContext.Provider>;
 }

--- a/src/context/ChampionsServerProvider.tsx
+++ b/src/context/ChampionsServerProvider.tsx
@@ -1,9 +1,10 @@
 import { ChampionsProvider } from '@/context/ChampionsContext';
 import { getLatestChampions } from '@/lib/championApi';
+import { ReactNode } from 'react';
 
 export default async function ChampionsServerProvider({
   children,
-}: Readonly<{ children: React.ReactNode }>) {
+}: Readonly<{ children: ReactNode }>) {
   const champions = await getLatestChampions().catch(() => []);
   return <ChampionsProvider champions={champions}>{children}</ChampionsProvider>;
 }

--- a/src/lib/championApi.ts
+++ b/src/lib/championApi.ts
@@ -93,6 +93,7 @@ export async function getChampionsByVersion(lolVersion: string): Promise<TChampi
     return {
       name: champion.name,
       id: champion.id,
+      key: champion.key,
       image: `https://ddragon.leagueoflegends.com/cdn/${lolVersion}/img/champion/${champion.image.full}`,
     };
   });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -47,7 +47,6 @@ export function closeDatabase(): void {
 // Persist handlers and registration state on globalThis to survive HMR reloads
 // This prevents duplicate process listeners across module reloads
 declare global {
-  // eslint-disable-next-line no-var
   var __overlol_dbHandlers:
     | {
         registered: boolean;

--- a/src/lib/matchApi.ts
+++ b/src/lib/matchApi.ts
@@ -6,6 +6,20 @@ import { Strings } from '@/utils/stringUtils';
 import { getLatestChampions } from './championApi';
 
 /**
+ * Custom error class for match API errors with HTTP status codes
+ */
+export class MatchApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public context?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = 'MatchApiError';
+  }
+}
+
+/**
  * Server-side function to fetch the puuid of a player by their game name and tag line.
  * @returns {Promise<string>} A promise of the player's PUUID.
  */
@@ -14,39 +28,74 @@ async function getPlayerPUUIDByGameNameAndTagLine(
   tagLine: string,
 ): Promise<string> {
   const riotApiKey = process.env.NEXT_RIOT_API_KEY;
+  const log = logger.child('match-service:fetch-puuid-player');
 
   if (Strings.isBlank(riotApiKey)) {
-    throw new Error('Riot API key is not set in environment variables');
+    log.error('Riot API key is not set in environment variables');
+    throw new MatchApiError('Server configuration error', 500);
   }
 
-  const response = await fetch(
-    `https://europe.api.riotgames.com/riot/account/v1/accounts/by-riot-id/${encodeURIComponent(gameName)}/${encodeURIComponent(tagLine)}`,
-    {
-      headers: {
-        accept: 'application/json',
-        'X-Riot-Token': riotApiKey!,
+  try {
+    const response = await fetch(
+      `https://europe.api.riotgames.com/riot/account/v1/accounts/by-riot-id/${encodeURIComponent(gameName)}/${encodeURIComponent(tagLine)}`,
+      {
+        headers: {
+          accept: 'application/json',
+          'X-Riot-Token': riotApiKey!,
+        },
+        signal: AbortSignal.timeout(5000),
+        next: {
+          revalidate: 1800, // 30 minutes cache
+          tags: ['PUUID', `PUUID-${gameName}-${tagLine}`],
+        },
       },
-      signal: AbortSignal.timeout(5000),
-      next: {
-        revalidate: 1800, // 30 minutes cache
-        tags: ['PUUID', `PUUID-${gameName}-${tagLine}`],
-      },
-    },
-  );
+    );
 
-  if (!response.ok) {
-    const log = logger.child('match-service:fetch-puuid-player');
-    log.error(`Failed to fetch player PUUID: ${response.status}, ${response.statusText}`);
-    throw new Error(`Failed to fetch player PUUID: ${response.status}`);
+    if (!response.ok) {
+      log.error(`Failed to fetch player PUUID: ${response.status}, ${response.statusText}`, {
+        gameName,
+        tagLine,
+      });
+
+      // Map Riot API status codes to appropriate errors
+      switch (response.status) {
+        case 404:
+          throw new MatchApiError(`Player ${gameName}#${tagLine} not found`, 404, {
+            gameName,
+            tagLine,
+          });
+        case 429:
+          throw new MatchApiError('Rate limit exceeded. Please try again later', 429);
+        case 403:
+          throw new MatchApiError('API access forbidden. Check API key', 403);
+        default:
+          throw new MatchApiError(
+            `Failed to fetch player data (${response.status})`,
+            response.status >= 500 ? 502 : 400,
+          );
+      }
+    }
+
+    const data = await response.json();
+
+    if (typeof data.puuid !== 'string') {
+      log.error('Unexpected response shape when fetching player PUUID', { data });
+      throw new MatchApiError('Invalid response from Riot API', 502);
+    }
+
+    return data.puuid;
+  } catch (error) {
+    // Re-throw MatchApiError as-is
+    if (error instanceof MatchApiError) {
+      throw error;
+    }
+
+    // Handle network/timeout errors
+    log.error('Network error when fetching player PUUID', { error, gameName, tagLine });
+    throw new MatchApiError('Failed to connect to Riot API. Please try again later', 503, {
+      originalError: error instanceof Error ? error.message : String(error),
+    });
   }
-
-  const data = await response.json();
-
-  if (typeof data.puuid !== 'string') {
-    throw new Error('Unexpected response shape when fetching player PUUID');
-  }
-
-  return data.puuid;
 }
 
 /**
@@ -56,48 +105,76 @@ async function getPlayerPUUIDByGameNameAndTagLine(
  */
 async function getCurrentMatchByPUUID(puuid: string): Promise<TParticipant[]> {
   const riotApiKey = process.env.NEXT_RIOT_API_KEY;
+  const log = logger.child('match-service:fetch-current-match');
 
   if (Strings.isBlank(riotApiKey)) {
-    throw new Error('Riot API key is not set in environment variables');
+    log.error('Riot API key is not set in environment variables');
+    throw new MatchApiError('Server configuration error', 500);
   }
 
-  const response = await fetch(
-    `https://euw1.api.riotgames.com/lol/spectator/v5/active-games/by-summoner/${puuid}`,
-    {
-      headers: {
-        accept: 'application/json',
-        'X-Riot-Token': riotApiKey!,
+  try {
+    const response = await fetch(
+      `https://euw1.api.riotgames.com/lol/spectator/v5/active-games/by-summoner/${puuid}`,
+      {
+        headers: {
+          accept: 'application/json',
+          'X-Riot-Token': riotApiKey!,
+        },
+        signal: AbortSignal.timeout(5000),
+        next: {
+          revalidate: 120, // 2 minutes cache
+          tags: ['CurrentMatch', `CurrentMatch-${puuid}`],
+        },
       },
-      signal: AbortSignal.timeout(5000),
-      next: {
-        revalidate: 120, // 2 minutes cache
-        tags: ['CurrentMatch', `CurrentMatch-${puuid}`],
-      },
-    },
-  );
-
-  if (!response.ok) {
-    const log = logger.child('match-service:fetch-current-match');
-    log.error(
-      `Failed to fetch current match for PUUID ${puuid}: ${response.status}, ${response.statusText}`,
     );
-    throw new Error(`Failed to fetch current match data: ${response.status}`);
+
+    if (!response.ok) {
+      log.error(
+        `Failed to fetch current match for PUUID ${puuid}: ${response.status}, ${response.statusText}`,
+      );
+
+      // Map Riot API status codes to appropriate errors
+      switch (response.status) {
+        case 404:
+          throw new MatchApiError('Player is not currently in an active game', 404, { puuid });
+        case 429:
+          throw new MatchApiError('Rate limit exceeded. Please try again later', 429);
+        case 403:
+          throw new MatchApiError('API access forbidden. Check API key', 403);
+        default:
+          throw new MatchApiError(
+            `Failed to fetch match data (${response.status})`,
+            response.status >= 500 ? 502 : 400,
+          );
+      }
+    }
+
+    const data = await response.json();
+    const champions = await getLatestChampions();
+
+    return data.participants.map(
+      (participant: { puuid: string; teamId: number; riotId: string; championId: number }) => ({
+        puuid: participant.puuid,
+        teamId: participant.teamId,
+        riotId: participant.riotId,
+        championId: participant.championId,
+        championName:
+          champions.find((champion) => champion.key === String(participant.championId))?.name ||
+          'Unknown Champion',
+      }),
+    ) as TParticipant[];
+  } catch (error) {
+    // Re-throw MatchApiError as-is
+    if (error instanceof MatchApiError) {
+      throw error;
+    }
+
+    // Handle network/timeout errors
+    log.error('Network error when fetching current match', { error, puuid });
+    throw new MatchApiError('Failed to connect to Riot API. Please try again later', 503, {
+      originalError: error instanceof Error ? error.message : String(error),
+    });
   }
-
-  const data = await response.json();
-  const champions = await getLatestChampions();
-
-  return data.participants.map(
-    (participant: { puuid: string; teamId: number; riotId: string; championId: number }) => ({
-      puuid: participant.puuid,
-      teamId: participant.teamId,
-      riotId: participant.riotId,
-      championId: participant.championId,
-      championName:
-        champions.find((champion) => champion.key === String(participant.championId))?.name ||
-        'Unknown Champion',
-    }),
-  ) as TParticipant[];
 }
 
 /**

--- a/src/lib/matchApi.ts
+++ b/src/lib/matchApi.ts
@@ -1,23 +1,10 @@
 'use server';
 
+import { MatchApiError } from '@/types/MatchApiError';
 import { TParticipant } from '@/types/MatchParticipantType';
 import { logger } from '@/utils/logger';
 import { Strings } from '@/utils/stringUtils';
 import { getLatestChampions } from './championApi';
-
-/**
- * Custom error class for match API errors with HTTP status codes
- */
-export class MatchApiError extends Error {
-  constructor(
-    message: string,
-    public statusCode: number,
-    public context?: Record<string, unknown>,
-  ) {
-    super(message);
-    this.name = 'MatchApiError';
-  }
-}
 
 /**
  * Server-side function to fetch the puuid of a player by their game name and tag line.

--- a/src/lib/matchApi.ts
+++ b/src/lib/matchApi.ts
@@ -1,0 +1,106 @@
+'use server';
+
+import { TParticipant } from '@/types/MatchParticipantType';
+import { Strings } from '@/utils/stringUtils';
+import { getLatestChampions } from './championApi';
+
+/**
+ * Server-side function to fetch the puuid of a player by their game name and tag line.
+ * @returns {Promise<string>} A promise of the player's PUUID.
+ */
+async function getPlayerPUUIDByGameNameAndTagLine(
+  gameName: string,
+  tagLine: string,
+): Promise<string> {
+  const riotApiKey = process.env.NEXT_RIOT_API_KEY;
+
+  if (Strings.isBlank(riotApiKey)) {
+    throw new Error('Riot API key is not set in environment variables');
+  }
+
+  const response = await fetch(
+    `https://europe.api.riotgames.com/riot/account/v1/accounts/by-riot-id/${gameName}/${tagLine}`,
+    {
+      headers: {
+        accept: 'application/json',
+        'X-Riot-Token': riotApiKey!,
+      },
+      signal: AbortSignal.timeout(5000),
+      next: {
+        revalidate: 1800, // 30 minutes cache
+        tags: ['PUUID', `PUUID-${gameName}-${tagLine}`],
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch player PUUID: ${response.status}`);
+  }
+
+  const data = await response.json();
+
+  if (typeof data.puuid !== 'string') {
+    throw new Error('Unexpected response shape when fetching player PUUID');
+  }
+
+  return data.puuid;
+}
+
+/**
+ * Server-side function to fetch the current match data of a player by their PUUID.
+ * @param {string} puuid - The player's PUUID.
+ * @returns {Promise<TParticipant[]>} A promise of the current match participants.
+ */
+async function getCurrentMatchByPUUID(puuid: string): Promise<TParticipant[]> {
+  const riotApiKey = process.env.NEXT_RIOT_API_KEY;
+
+  if (Strings.isBlank(riotApiKey)) {
+    throw new Error('Riot API key is not set in environment variables');
+  }
+
+  const response = await fetch(
+    `https://euw1.api.riotgames.com/lol/spectator/v5/active-games/by-summoner/${puuid}`,
+    {
+      headers: {
+        accept: 'application/json',
+        'X-Riot-Token': riotApiKey!,
+      },
+      signal: AbortSignal.timeout(5000),
+      next: {
+        revalidate: 1800, // 30 minutes cache
+        tags: ['CurrentMatch', `CurrentMatch-${puuid}`],
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch current match data: ${response.status}`);
+  }
+
+  const data = await response.json();
+  const champions = await getLatestChampions();
+
+  return data.participants.map((participant: TParticipant) => ({
+    puuid: participant.puuid,
+    teamId: participant.teamId,
+    riotId: participant.riotId,
+    championId: participant.championId,
+    championName:
+      champions.find((champion) => champion.key === String(participant.championId))?.name ||
+      'Unknown Champion',
+  })) as TParticipant[];
+}
+
+/**
+ * Gets the current match participants for a player identified by their game name and tag line.
+ * @param {string} gameName - The player's game name.
+ * @param {string} tagLine - The player's tag line.
+ * @returns {Promise<TParticipant[]>} A promise of the current match participants.
+ */
+export async function getCurrentMatchByGameNameAndTagLine(
+  gameName: string,
+  tagLine: string,
+): Promise<TParticipant[]> {
+  const puuid = await getPlayerPUUIDByGameNameAndTagLine(gameName, tagLine);
+  return getCurrentMatchByPUUID(puuid);
+}

--- a/src/lib/matchApi.ts
+++ b/src/lib/matchApi.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { TParticipant } from '@/types/MatchParticipantType';
+import { logger } from '@/utils/logger';
 import { Strings } from '@/utils/stringUtils';
 import { getLatestChampions } from './championApi';
 
@@ -34,6 +35,8 @@ async function getPlayerPUUIDByGameNameAndTagLine(
   );
 
   if (!response.ok) {
+    const log = logger.child('match-service:fetch-puuid-player');
+    log.error(`Failed to fetch player PUUID: ${response.status}, ${response.statusText}`);
     throw new Error(`Failed to fetch player PUUID: ${response.status}`);
   }
 
@@ -67,13 +70,17 @@ async function getCurrentMatchByPUUID(puuid: string): Promise<TParticipant[]> {
       },
       signal: AbortSignal.timeout(5000),
       next: {
-        revalidate: 1800, // 30 minutes cache
+        revalidate: 120, // 2 minutes cache
         tags: ['CurrentMatch', `CurrentMatch-${puuid}`],
       },
     },
   );
 
   if (!response.ok) {
+    const log = logger.child('match-service:fetch-current-match');
+    log.error(
+      `Failed to fetch current match for PUUID ${puuid}: ${response.status}, ${response.statusText}`,
+    );
     throw new Error(`Failed to fetch current match data: ${response.status}`);
   }
 

--- a/src/lib/matchApi.ts
+++ b/src/lib/matchApi.ts
@@ -19,7 +19,7 @@ async function getPlayerPUUIDByGameNameAndTagLine(
   }
 
   const response = await fetch(
-    `https://europe.api.riotgames.com/riot/account/v1/accounts/by-riot-id/${gameName}/${tagLine}`,
+    `https://europe.api.riotgames.com/riot/account/v1/accounts/by-riot-id/${encodeURIComponent(gameName)}/${encodeURIComponent(tagLine)}`,
     {
       headers: {
         accept: 'application/json',
@@ -80,15 +80,17 @@ async function getCurrentMatchByPUUID(puuid: string): Promise<TParticipant[]> {
   const data = await response.json();
   const champions = await getLatestChampions();
 
-  return data.participants.map((participant: TParticipant) => ({
-    puuid: participant.puuid,
-    teamId: participant.teamId,
-    riotId: participant.riotId,
-    championId: participant.championId,
-    championName:
-      champions.find((champion) => champion.key === String(participant.championId))?.name ||
-      'Unknown Champion',
-  })) as TParticipant[];
+  return data.participants.map(
+    (participant: { puuid: string; teamId: number; riotId: string; championId: number }) => ({
+      puuid: participant.puuid,
+      teamId: participant.teamId,
+      riotId: participant.riotId,
+      championId: participant.championId,
+      championName:
+        champions.find((champion) => champion.key === String(participant.championId))?.name ||
+        'Unknown Champion',
+    }),
+  ) as TParticipant[];
 }
 
 /**

--- a/src/types/ChampionType.ts
+++ b/src/types/ChampionType.ts
@@ -1,5 +1,6 @@
 export type TChampion = {
   id: string;
+  key: string;
   name: string;
   image: string;
 };

--- a/src/types/MatchApiError.ts
+++ b/src/types/MatchApiError.ts
@@ -1,0 +1,13 @@
+/**
+ * Custom error class for match API errors with HTTP status codes
+ */
+export class MatchApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public context?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = 'MatchApiError';
+  }
+}

--- a/src/types/MatchParticipantType.ts
+++ b/src/types/MatchParticipantType.ts
@@ -1,0 +1,7 @@
+export type TParticipant = {
+  puuid: string;
+  teamId: number;
+  riotId: string;
+  championId: string;
+  championName: string;
+};

--- a/src/types/MatchParticipantType.ts
+++ b/src/types/MatchParticipantType.ts
@@ -2,6 +2,6 @@ export type TParticipant = {
   puuid: string;
   teamId: number;
   riotId: string;
-  championId: string;
+  championId: number;
   championName: string;
 };

--- a/src/utils/leaderboardUtils.ts
+++ b/src/utils/leaderboardUtils.ts
@@ -3,9 +3,10 @@ import { logger } from './logger';
 
 const log = logger.child('api:leaderboard:fetchRegionRank');
 
+// Pattern supports numbers with commas (e.g., "1,234")
+// Limit quantifiers to prevent ReDoS attacks
 const extractRegionRank = (html: string): string => {
-  // Pattern supports numbers with commas (e.g., "1,234")
-  const match = /Ladder Rank\s+<span[^>]*>([\d,]+)<\/span>/.exec(html);
+  const match = /Ladder Rank\s{1,10}<span[^>]{0,100}>([\d,]{1,20})<\/span>/.exec(html);
   return match?.[1] ?? '';
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Load match data by entering gameName#tagLine to pre-fill blue/red teams (new two-step "Load data" flow).
  * Drag-and-drop player reordering within the overlay form.
  * New server API endpoint to fetch current match participants by gameName#tagLine.

* **Bug Fixes / Stability**
  * Tighter leaderboard parsing to avoid pathological regex behavior.

* **Chores**
  * Champion and participant data include additional identifiers.
  * Editor spell-check entry and minor formatting tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->